### PR TITLE
minor content/formatting fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,44 +2,43 @@
 
 ## Objectives
 
-1. Construct a nested params hash with data about the primary object and a belongs to and has many association.
+1. Construct a nested `params` hash with data about the primary object and a `belongs_to` and `has_many` association.
 2. Use the conventional key names for associated data (association_attributes).
-3. Name form inputs correctly to create a nested params hash with belongs to and has many associated data.
-4. Define a conventional association writer for the primary model to properly instantiate associations based on the nested params association data.
-5. Define a custom association writer for the primary model to properly instantiate associations with custom logic (like unique by name) on the nested params association data.
-5. Use fields_for to generate the association fields.
+3. Name form inputs correctly to create a nested `params` hash with `belongs_to` and `has_many` associated data.
+4. Define a conventional association writer for the primary model to properly instantiate associations based on the nested `params` association data.
+5. Define a custom association writer for the primary model to properly instantiate associations with custom logic (like unique by name) on the nested `params` association data.
+6. Use `fields_for` to generate the association fields.
 
 ## Data model
 
 Let's say we're writing an address book.
 
-Each Person can have multiple addresses. Addresses have a bunch of address info fields.
+Each `Person` can have multiple addresses. Each `Address` has a bunch of address info fields.
 
 Our data model looks like this:
 
-  * Person
-    * a person has many addresses
-    * person.name: string
-  * Address
-    * an address has one person
-    * address.street_address_1: string
-    * address.street_address_2: string
-    * address.city: string
-    * address.zipcode: string
-    * address.address_type: string
+  * `Person`
+    * has many `addresses`
+    * has a `name` (string)
+  * `Address`
+    * has one `person`
+    * has the first line of the street address stored as `street_address_1` (string)
+    * has the second line of the street address stored as `street_address_2` (string)
+    * has a `city` (string)
+    * has a `zipcode` (string)
+    * has an `address_type` (string)
 
 ## Creating people
 
-How do we write our Person form? We don't want to require our user to first create an address, then create that person. That's annoying. We want a single form for a Person containing several slots for addresses.
+How do we write our `Person` form? We don't want to require our user to first create an `Address`, then create that `Person`. That's annoying. We want a single form for a `Person` containing several slots for their `addresses`.
 
-Previously, we wrote setters like `Song#artist_name=` to find or create an Artist and connect them to the song.
+Previously, we wrote setters like `Song#artist_name=` to find or create an `Artist` and connect them to the song.
 
-That won't work here, because an address contains more than one field. In the `Artist` case we were just doing the `name`. With `Address` it's "structured data". All that really means is it has multiple fields attached to it. When we build a form
-for it, the form will send a different key for each field in each address. This can get a bit unwieldy so we generally try to group a hash within the params hash – makes things much neater. Spoiler: Rails has a way to send this across as a hash.
+That won't work here, because an address contains more than one field. In the `Artist` case we were just doing the `name`. With `Address`, it's "structured data". All that really means is it has multiple fields attached to it. When we build a form for it, the form will send a different key for each field in each address. This can get a bit unwieldy so we generally try to group a hash within the `params` hash, which makes things much neater. Spoiler alert: Rails has a way to send this across as a hash.
 
-The complete `params` object for creating a person will look like the following. Using "0" and "1" as keys can seem a bit odd, but it makes everything else work moving forward. This hash is now more versatile. You can use it like an array by just doing `params[:addresses_attributes][0.to_s]` or like a normal hash.
+The complete `params` object for creating a `Person` will look like the following. Using "0" and "1" as keys can seem a bit odd, but it makes everything else work moving forward. This hash is now more versatile. You can access nested values the standard way, with `params[:person][:addresses_attributes]["0"]` returning all of the information about the first address at 33 West 26th St.
 
-```
+```ruby
 {
   :person => {
     :name => "Avi",
@@ -66,9 +65,9 @@ The complete `params` object for creating a person will look like the following.
 }
 ```
 
-Notice the `address_attributes` key. That key, is similar to our `artist_name` key that we had before. Last time we handled this by writing a `artist_name=` method. In this case we are going to do something *super* similar. This time, instead of writing our own `addresses_attributes` method, we are going to let Rails take care of it for us. We are going to use `accepts_nested_attributes_for` and the `fields_for` FormHelper.
+Notice the `addresses_attributes` key. That key is similar to the `artist_name` key we used previously. Last time, we handled this by writing a `artist_name=` method. In this case, we're going to do something *super* similar. Instead of writing our own `addresses_attributes=` method, we'll let Rails take care of it for us. We're going to use `accepts_nested_attributes_for` and the `fields_for` FormHelper.
 
-Last time, we first wrote our setter method in the model. This time let's modify our `Person` model to `accepts_nested_attributes_for :addresses`
+Last time, we first wrote our setter method in the model. This time let's modify our `Person` model to include an `accepts_nested_attributes_for :addresses` line.
 
 ```ruby
 class Person < ActiveRecord::Base
@@ -80,7 +79,7 @@ end
 
 Now open up `rails c` and run our `addresses_attributes` method that was created for us by `accepts_nested_attributes_for`.
 
-```ruby
+```shell
 2.2.3 :018 > new_person = Person.new
  => #<Person id: nil, name: nil, created_at: nil, updated_at: nil>
 
@@ -95,11 +94,11 @@ Now open up `rails c` and run our `addresses_attributes` method that was created
    (0.6ms)  commit transaction
 ```
 
-This is a bit hard to read, but you'll notice that we have a method called `addresses_attributes=`. You didn't write that, `accepts_nested_attributes_for` wrote that. Then when we called `new_person.save` it created both the `Person` object and the two `Address` objects. Boom!
+This is a bit hard to read, but you'll notice that we have a method called `addresses_attributes=`. You didn't write that; `accepts_nested_attributes_for` wrote that. Then when we called `new_person.save` it created both the `Person` object and the two `Address` objects. Boom!
 
 Now, we just need to get our form to create a `params` hash like that. Easy Peasy. We are going to use `fields_for` to make this happen.
 
-```ruby
+```erb
 # app/views/people/form.html.erb
 <%= form_for @person do |f| %>
   <%= f.text_field :name %>
@@ -125,21 +124,18 @@ Now, we just need to get our form to create a `params` hash like that. Easy Peas
 <% end %>
 ```
 
-The `fields_for` line gives something nice and english-y. In that block are the fields for the addresses. Love Rails.
+The `fields_for` line gives something nice and English-y. In that block are the fields for the addresses. Love Rails.
 
-Load the page up and see the majestic beauty of what you and Rails have written together. What!!!! Nothing is there.
+Load up the page, and see the majestic beauty of what you and Rails have written together. What?! Nothing is there.
 
 
 ## Creating stubs
 
-We're asking rails to generate `fields_for` each of the Person's addresses. But
-when we're first creating a Person, they have no addresses. Just like  `f.text_field :name` will have nothing in the text field if there is no name, `f.fields_for :addresses` will have no addresses fields if there are no addresses.
+We're asking Rails to generate `fields_for` each of the `Person`'s addresses. However, when we first create a `Person`, they have no addresses. Just like `f.text_field :name` will have nothing in the text field if there is no name, `f.fields_for :addresses` will have no address fields if there are no addresses.
 
-We'll take the most straightforward way out: when we create a Person in the
-PeopleController, we'll add two empty addresses to fill out. The final controller
-looks like this:
+We'll take the most straightforward way out: when we create a `Person` in the `PeopleController`, we'll add two empty addresses to fill out. The final controller looks like this:
 
-```
+```ruby
 class PeopleController < ApplicationController
   def new
     @person = Person.new
@@ -160,22 +156,22 @@ class PeopleController < ApplicationController
 end
 ```
 
-Now, refresh the page and you'll see two lovely address forms. Try and hit submit and it isn't going to work. One last hurdle. We have new param keys, which means we need to modify our `person_params` method to accept them. Your new `person_params` should now look like this:
+Now, refresh the page, and you'll see two lovely address forms. Try to hit submit, and it isn't going to work. One last hurdle. We have new `params` keys, which means we need to modify our `person_params` method to accept them. Your `person_params` method should now look like this:
 
 ```ruby
-  def person_params
-    params.require(:person).permit(
-      :name,
-      addresses_attributes: [
-        :street_address_1,
-        :street_address_2,
-        :city,
-        :state,
-        :zipcode,
-        :address_type
-      ]
-    )
-  end
+def person_params
+  params.require(:person).permit(
+    :name,
+    addresses_attributes: [
+      :street_address_1,
+      :street_address_2,
+      :city,
+      :state,
+      :zipcode,
+      :address_type
+    ]
+  )
+end
 ```
 
 
@@ -183,12 +179,13 @@ Now, refresh the page and you'll see two lovely address forms. Try and hit submi
 
 One situation we can't use `accepts_nested_attributes_for` is when we want to avoid duplicates of the row we're creating.
 
-In our address book app, perhaps it's reasonable to have duplicate address rows. Like, both Jerry and Tim live on 22 Elm Street, so there are two address rows for 22 Elm Street. That's fine for those purposes.
+In our address book app, perhaps it's reasonable to have duplicate address rows. For instance, both Jerry and Tim live on 22 Elm Street, so there are two address rows for 22 Elm Street. That's fine for those purposes.
 
-But say we had a database of Songs and Artists. We would want Artist rows to be unique, so that `Artist.find_by(name: 'Tori Amos').songs` returns what we'd expect. If we want to be able to create Artists while creating Songs, we'll need to use `find_or_create_by` in our `artist_attributes=` method:
+But say we have a database of songs and artists. We would want `Artist` rows to be unique, so that `Artist.find_by(name: 'Tori Amos').songs` returns what we'd expect. If we want to be able to create artists _while_ creating songs, we'll need to use `find_or_create_by` in our `artist_attributes=` method:
 
 ```ruby
 # app/models/song.rb
+
 class Song < ActiveRecord::Base
   def artist_attributes=(artist)
     self.artist = Artist.find_or_create_by(name: artist.name)
@@ -197,9 +194,9 @@ class Song < ActiveRecord::Base
 end
 ```
 
-This looks up existing Artists by name. If it doesn't exist, one is created. Then we update an artist's attributes with the ones we were given. We could choose to do something else, if we didn't want to allow bulk assigning of an artist's information through a song.
+This looks up existing artists by name. If no matching artist is found, one is created. Then we update the artist's attributes with the ones we were given. We could also choose to do something else if we didn't want to allow bulk assigning of an artist's information through a song.
 
-Note that `accepts_nested_attributes_for` and setter methods (e.g., `artist_attributes=`) aren't necessarily mutually exclusive. It's important to evaluate the needs of your specific use case and to choose the approach that makes the most sense. Keep in mind, too, that setter methods are useful for more than just avoiding duplicates — that's just one domain where they come in handy.
+Note that `accepts_nested_attributes_for` and setter methods (e.g., `artist_attributes=`) aren't necessarily mutually exclusive. It's important to evaluate the needs of your specific use case and choose the approach that makes the most sense. Keep in mind, too, that setter methods are useful for more than just avoiding duplicates –– that's just one domain where they come in handy.
 
 ## Video Review 
 

--- a/README.md
+++ b/README.md
@@ -100,28 +100,33 @@ This is a bit hard to read, but you'll notice that we have a method called `addr
 Now, we just need to get our form to create a `params` hash like that. Easy Peasy. We are going to use `fields_for` to make this happen.
 
 ```erb
-# app/views/people/form.html.erb
+# app/views/people/new.html.erb
+
 <%= form_for @person do |f| %>
-  <%= f.text_field :name %>
+  <%= f.label :name %>
+  <%= f.text_field :name %><br>
+
   <%= f.fields_for :addresses do |addr| %>
     <%= addr.label :street_address_1 %>
-    <%= addr.text_field :street_address_1 %><br />
+    <%= addr.text_field :street_address_1 %><br>
 
     <%= addr.label :street_address_2 %>
-    <%= addr.text_field :street_address_2 %><br />
+    <%= addr.text_field :street_address_2 %><br>
 
     <%= addr.label :city %>
-    <%= addr.text_field :city %><br />
+    <%= addr.text_field :city %><br>
 
     <%= addr.label :state %>
-    <%= addr.text_field :state %><br />
+    <%= addr.text_field :state %><br>
 
     <%= addr.label :zipcode %>
-    <%= addr.text_field :zipcode %><br />
+    <%= addr.text_field :zipcode %><br>
 
     <%= addr.label :address_type %>
-   <%= addr.text_field :address_type %><br />
- <% end %>
+    <%= addr.text_field :address_type %><br>
+  <% end %>
+
+  <%= f.submit %>
 <% end %>
 ```
 
@@ -145,8 +150,12 @@ class PeopleController < ApplicationController
   end
 
   def create
-    @person = Person.create(person_params)
-    redirect_to people_path(@person)
+    person = Person.create(person_params)
+    redirect_to people_path
+  end
+  
+  def index
+    @people = Person.all
   end
 
   private

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Now open up `rails c` and run our `addresses_attributes` method that was created
   SQL (0.3ms)  INSERT INTO "addresses" ("street_address_1", "street_address_2", "city", "state", "zipcode", "address_type", "person_id", "created_at", "updated_at") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)  [["street_address_1", "33 West 26"], ["street_address_2", "Floor 2"], ["city", "NYC"], ["state", "NY"], ["zipcode", "10004"], ["address_type", "work1"], ["person_id", 3], ["created_at", "2016-01-14 11:57:00.403152"], ["updated_at", "2016-01-14 11:57:00.403152"]]
   SQL (0.1ms)  INSERT INTO "addresses" ("street_address_1", "street_address_2", "city", "state", "zipcode", "address_type", "person_id", "created_at", "updated_at") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)  [["street_address_1", "11 Broadway"], ["street_address_2", "Suite 260"], ["city", "NYC"], ["state", "NY"], ["zipcode", "10004"], ["address_type", "work2"], ["person_id", 3], ["created_at", "2016-01-14 11:57:00.405973"], ["updated_at", "2016-01-14 11:57:00.405973"]]
    (0.6ms)  commit transaction
+ => true
 ```
 
 This is a bit hard to read, but you'll notice that we have a method called `addresses_attributes=`. You didn't write that; `accepts_nested_attributes_for` wrote that. Then when we called `new_person.save` it created both the `Person` object and the two `Address` objects. Boom!


### PR DESCRIPTION
- `params[:addresses_attributes][0.to_s]` --> `params[:person][:addresses_attributes]["0"]`
- `address_attributes` --> `addresses_attributes`
- `addresses_attributes` --> `addresses_attributes=`
- fix comma splices
- fix syntax highlighting for code snippets
